### PR TITLE
Fix pass through of arguments that include spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ Yes, the shim will have vim's icon and looks exactly like `vim.exe` in Windows e
 
 As this is **Windows Exclusive**, you need Visual Studio 2022+ with Windows SDK installed. Normally I would use CMake, but it is considerably harder (not impossible) when you need access to OS specific tools, especially native resources (which I utilise heavily to do the magic). It is also very well integrated with `vcpkg`.
 
-`shmake` (but not shim) has dependency on:
+`shmake` has dependency on:
 - `boost::program_options` to present you with a nice command line.
+- `boost::algorithm` to have access to some string manipulation algorithms.
+
+`shim` has only (to kept it as small and light as possible) dependency on:
 - `boost::algorithm` to have access to some string manipulation algorithms.
 
 All the dependencies are installed via [vcpkg](https://github.com/microsoft/vcpkg).  
@@ -61,8 +64,6 @@ Also note that `Debug` builds used shared dependencies while `Release` builds us
 ```
 vcpkg install boost-program-options:x64-windows boost-program-options:x64-windows-static boost-algorithm:x64-windows boost-algorithm:x64-windows-static
 ```
-
-`shim` **does not have any dependencies** and is kept as small and light as possible.
 
 ### Extra Oddness
 

--- a/shim/shim.cpp
+++ b/shim/shim.cpp
@@ -50,8 +50,6 @@ int wmain(int argc, wchar_t* argv[], wchar_t *envp[])
     get_caps(caps_str, cap_clipboard, cap_no_kill);
 
     // args
-    auto args = args_pattern;
-
     wstring passed_arg;
     for (int i = 1; i < argc; i++)
     {
@@ -59,11 +57,19 @@ int wmain(int argc, wchar_t* argv[], wchar_t *envp[])
         passed_arg += argv[i];
     }
 
-    // do token replacement regardless of whether we have an argument or not - if we do, it needs to be deleted anyway
-    size_t pos = args.find(CMD_TOKEN);
-    if (pos != string::npos)
+    auto args = args_pattern;
+    if (args.empty())
     {
-        args.replace(pos, CMD_TOKEN.size(), passed_arg);
+        args = passed_arg;
+    }
+    else
+    {
+        // do token replacement regardless of whether we have an argument or not - if we do, it needs to be deleted anyway
+        size_t pos = args.find(CMD_TOKEN);
+        if (pos != string::npos)
+        {
+            args.replace(pos, CMD_TOKEN.size(), passed_arg);
+        }
     }
 
     wstring full_cmd = image_path;

--- a/shim/shim.cpp
+++ b/shim/shim.cpp
@@ -2,6 +2,7 @@
 #include <string>
 #include "windows.h"
 #include "resource.h"
+#include <boost/algorithm/string/replace.hpp>
 #include "../shmake/resources.h"
 #include "../shmake/util.h"
 
@@ -54,7 +55,17 @@ int wmain(int argc, wchar_t* argv[], wchar_t *envp[])
     for (int i = 1; i < argc; i++)
     {
         if (i > 1) passed_arg += L" ";
-        passed_arg += argv[i];
+        wstring arg = argv[i];
+
+        // if an arg contains a space, encapsulate it into double quotes
+        // after having escape the double quotes it contains.
+        if (arg.find(' ') != string::npos)
+        {
+            boost::replace_all(arg, L"\"", L"\\\"");
+            arg.insert(0, L"\"");
+            arg.append(L"\"");
+        }
+        passed_arg += arg;
     }
 
     auto args = args_pattern;


### PR DESCRIPTION
Not expected but I’ve take the time to fix #7 since I’ve found another issue for which I’ve had no workaround : Arguments that contain spaces where not correctly transmitted.

Instead of being send as a single argument they were send as multiple arguments since they were not encapsulated into double quotes.

NB : There is probably still some issues if an argument include spaces, and ends with a backslash or contains a backslash followed by a double quotes, because there is an awkward logic in command line parsing based on the parity of backslashes before a double quote that has always be hard to manage and understand for me (see : 
https://web.archive.org/web/20220604063845/https://docs.microsoft.com/en-us/previous-versions//17w5ykft(v=vs.85)?redirectedfrom=MSDN)