### PR TITLE
Fix Copy/Paste from another process

### DIFF
--- a/shim/shim.cpp
+++ b/shim/shim.cpp
@@ -105,12 +105,12 @@ int wmain(int argc, wchar_t* argv[], wchar_t *envp[])
         ::AssignProcessToJobObject(hJob, pi.hProcess);
 
         JOBOBJECT_BASIC_UI_RESTRICTIONS jUI = { 0 };
-        jUI.UIRestrictionsClass = JOB_OBJECT_UILIMIT_DESKTOP |
-            JOB_OBJECT_UILIMIT_DISPLAYSETTINGS |
-            JOB_OBJECT_UILIMIT_EXITWINDOWS |
-            JOB_OBJECT_UILIMIT_GLOBALATOMS |
-            JOB_OBJECT_UILIMIT_HANDLES |
-            JOB_OBJECT_UILIMIT_SYSTEMPARAMETERS;
+        //jUI.UIRestrictionsClass = JOB_OBJECT_UILIMIT_DESKTOP; |
+        //    JOB_OBJECT_UILIMIT_DISPLAYSETTINGS |
+        //    JOB_OBJECT_UILIMIT_EXITWINDOWS |
+        //    JOB_OBJECT_UILIMIT_GLOBALATOMS |
+        //    JOB_OBJECT_UILIMIT_HANDLES |
+        //    JOB_OBJECT_UILIMIT_SYSTEMPARAMETERS;
         if (!cap_clipboard)
         {
             jUI.UIRestrictionsClass |= JOB_OBJECT_UILIMIT_READCLIPBOARD | JOB_OBJECT_UILIMIT_WRITECLIPBOARD;
@@ -133,7 +133,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t *envp[])
             }
         }
 
-        JOBOBJECT_CPU_RATE_CONTROL_INFORMATION jCpu = { 0 };
+        //JOBOBJECT_CPU_RATE_CONTROL_INFORMATION jCpu = { 0 };
 
         // now the process starts for real
         //wcout << L"resuming" << endl;


### PR DESCRIPTION
This fix #14 

I’ve just remove all process limitations because the issue occurs as soon as I add any one of them.
I’ can’t explain exactly why those execution limitations that doesn’t seems related to clipboard cause the issue.
But in the same time I don’t know why those limitations are apply by default in the first place?
So it do not feel so bad, at least for my needs to remove all of them without providing any way to control them.

Maybe we can come with a better fix, and new options to control the shim restrictions.
But in the same time I wonder why we should apply any restriction with a shim?
IMHO shimming should not try to mimic what we can do with container technologies.